### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/wowemulation-dev/rilua/compare/v0.1.0...v0.1.1) - 2026-02-15
+
+### Changed
+
+- centralize platform FFI and migrate safe operations to Rust std
+
 ### Added
 
 - Cross-platform compilation support for Linux, macOS, and Windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "flamegraph",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/wowemulation-dev/rilua/compare/v0.1.0...v0.1.1) - 2026-02-15

### Changed

- centralize platform FFI and migrate safe operations to Rust std

### Added

- Cross-platform compilation support for Linux, macOS, and Windows
- Centralized platform abstraction layer (`src/platform.rs`) with
  `#[cfg(target_os)]` dispatch for all libc FFI declarations

### Changed

- Replaced `isatty` FFI with `std::io::IsTerminal` in CLI binary
- Replaced `time(NULL)` FFI with `SystemTime::now()` for current time
- Replaced `errno`/`strerror` FFI with `std::io::Error::last_os_error()`
  in I/O library error reporting (4 sites)
- Replaced `mkstemp`/`tmpnam` FFI with `File::create_new()` and
  `std::env::temp_dir()` for `os.tmpname`
- Moved scattered libc FFI declarations from `io.rs`, `os.rs`, and
  `execute.rs` into `platform.rs`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).