### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/wowemulation-dev/rilua/compare/v0.1.2...v0.1.3) - 2026-02-16
+
+### Performance
+
+- GC and traceback optimizations (phase 3)
+- hash-based constant pool deduplication in compiler
+
 ## [0.1.2](https://github.com/wowemulation-dev/rilua/compare/v0.1.1...v0.1.2) - 2026-02-15
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "flamegraph",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/wowemulation-dev/rilua/compare/v0.1.2...v0.1.3) - 2026-02-16

### Performance

- GC and traceback optimizations (phase 3)
- hash-based constant pool deduplication in compiler
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).