### PR TITLE
docs: sync documentation with current code state

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Tests: api, attrib, big, calls, checktable, closure, code, constructs,
 db, errors, events, files, gc, literals, locals, main, math, nextvar,
 pm, sort, strings, vararg, verybig.
 
-The `all.lua` runner completes in ~17 seconds.
+The `all.lua` runner completes in ~3 seconds (release mode).
 
 See `docs/testing.md` for details on running modes and the comparison
 script.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,12 @@ Benefits of the AST phase:
 src/
   lib.rs              Public API (Lua struct, traits, types)
   error.rs            Error types (syntax, runtime, argument)
+  conversion.rs       IntoLua/FromLua trait implementations
+  handles.rs          Table/Function/Thread/AnyUserData handle types
+  platform.rs         Centralized FFI declarations (libc wrappers)
+  bin/
+    rilua.rs          Standalone interpreter (matches lua.c)
+    riluac.rs         Bytecode compiler/lister (matches luac)
   compiler/
     mod.rs            Compiler module root
     lexer.rs          Tokenizer (source -> tokens)
@@ -84,6 +90,11 @@ src/
     string.rs         String interning
     closure.rs        Closures and upvalues
     callinfo.rs       Call stack (CallInfo chain)
+    metatable.rs      Metamethod dispatch
+    debug_info.rs     Debug info and variable name resolution
+    dump.rs           Binary chunk serialization (string.dump)
+    undump.rs         Binary chunk deserialization (loadstring)
+    listing.rs        Bytecode listing (riluac -l output)
   stdlib/
     mod.rs            Standard library registration
     base.rs           Base library (print, assert, type, etc.)
@@ -95,28 +106,27 @@ src/
     os.rs             OS library
     debug.rs          Debug library
     package.rs        Package/module library
+    testlib.rs        T test module (PUC-Rio ltests.c equivalent)
 ```
 
 ## Key Architectural Decisions
 
-Each decision is documented in detail in its own file:
-
-| Decision | Choice | Rationale | Detail |
-|----------|--------|-----------|--------|
-| Compilation pipeline | Lexer -> Parser -> AST -> Compiler | Separation of concerns, testability | [pipeline.md](pipeline.md) |
-| Instruction set | PUC-Rio's 38 opcodes as Rust enums | Behavioral equivalence, type safety | [instructions.md](instructions.md) |
-| Value representation | Rust enum (Val) | Type safety, pattern matching | [values.md](values.md) |
-| Garbage collection | Arena with generational indices | Zero unsafe, mark-sweep | [gc.md](gc.md) |
-| Tables | Array + hash dual representation | Performance, PUC-Rio compatibility | [tables.md](tables.md) |
-| Strings | Interned with cached hash | Pointer equality, O(1) comparison | [strings.md](strings.md) |
-| Closures and upvalues | Open/closed upvalue model | PUC-Rio semantics | [closures.md](closures.md) |
-| Error handling | Result-based | Idiomatic Rust, no longjmp | [errors.md](errors.md) |
-| Public API | Trait-based, Rust-idiomatic | Ergonomic embedding | [api.md](api.md) |
-| Standard library | Modular, per-library files | Independent testing, optional loading | [stdlib.md](stdlib.md) |
-| Call stack | Dynamic CallInfo array | Separate from value stack, index-based | [callinfo.md](callinfo.md) |
-| Metatables | PUC-Rio 5.1.1 dispatch semantics | 17 metamethods, type coercion rules | [metatables.md](metatables.md) |
-| Coroutines | Threads with shared GC heap | Independent stacks, cooperative multithreading | [coroutines.md](coroutines.md) |
-| Testing strategy | Spec-driven, multi-layer | Correctness assurance | [testing.md](testing.md) |
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Compilation pipeline | Lexer -> Parser -> AST -> Compiler | Separation of concerns, testability |
+| Instruction set | PUC-Rio's 38 opcodes as Rust enums | Behavioral equivalence, type safety |
+| Value representation | Rust enum (Val) | Type safety, pattern matching |
+| Garbage collection | Arena with generational indices | Zero unsafe, mark-sweep |
+| Tables | Array + hash dual representation | Performance, PUC-Rio compatibility |
+| Strings | Interned with cached hash | Pointer equality, O(1) comparison |
+| Closures and upvalues | Open/closed upvalue model | PUC-Rio semantics |
+| Error handling | Result-based | Idiomatic Rust, no longjmp |
+| Public API | Trait-based, Rust-idiomatic | Ergonomic embedding ([api.md](api.md)) |
+| Standard library | Modular, per-library files | Independent testing, optional loading ([stdlib.md](stdlib.md)) |
+| Call stack | Dynamic CallInfo array | Separate from value stack, index-based |
+| Metatables | PUC-Rio 5.1.1 dispatch semantics | 17 metamethods, type coercion rules |
+| Coroutines | Threads with shared GC heap | Independent stacks, cooperative multithreading |
+| Testing strategy | Spec-driven, multi-layer | Correctness assurance ([testing.md](testing.md)) |
 
 ## Reference Implementations
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,7 @@ oracle comparison for behavioral equivalence, integration tests
 for language semantics, PUC-Rio official test suite as the
 compatibility target.**
 
-Current: 1304 tests (596 unit, 431 integration, 277 oracle).
+Current: 1316 tests (578 unit, 431 integration, 267 oracle, 40 doc/other).
 All oracle test cases pass against PUC-Rio 5.1.1. All 5 layers
 are active. PUC-Rio official test suite: all 23 files pass via
 the `all.lua` runner.
@@ -289,9 +289,10 @@ individual tests to pass first, plus:
 
 #### T Module
 
-rilua provides a partial implementation of PUC-Rio's internal test
-library (`T` global). Activate it with the `RILUA_TEST_LIB=1`
-environment variable. Implemented functions:
+rilua implements PUC-Rio's internal test library (`T` global),
+the Rust equivalent of `ltests.c`. Activate it with the
+`RILUA_TEST_LIB=1` environment variable. 25 functions are
+registered:
 
 | Function | Description |
 |----------|-------------|
@@ -304,14 +305,26 @@ environment variable. Implemented functions:
 | `T.resume` | Resumes a coroutine (no arguments) |
 | `T.d2s` | Converts f64 to 8-byte native-endian string |
 | `T.s2d` | Converts 8-byte native-endian string to f64 |
-
-Not implemented: `T.testC` (C API mini-interpreter), `T.checkmemory`,
-`T.totalmem`.
+| `T.testC` | C API mini-interpreter (28 commands) |
+| `T.newuserdata` | Create userdata with given byte size |
+| `T.udataval` | Return unique integer ID for userdata |
+| `T.pushuserdata` | Find/create userdata by its ID |
+| `T.ref` | Store object in registry, return integer key |
+| `T.unref` | Remove registry entry |
+| `T.getref` | Get value from registry by key |
+| `T.upvalue` | Get/set upvalue n of closure f |
+| `T.checkmemory` | No-op stub (GC consistency check) |
+| `T.gsub` | String substitution |
+| `T.doonnewstack` | Run code in a new coroutine |
+| `T.newstate` | Create independent Lua state |
+| `T.closestate` | Close a state created by newstate |
+| `T.doremote` | Execute code string in remote state |
+| `T.loadlib` | Load standard libraries into remote state |
+| `T.totalmem` | Get/set memory limit (OOM simulation) |
 
 Four tests (`api.lua`, `checktable.lua`, `closure.lua`, `code.lua`)
 use T extensively. When `T` is nil, guarded sections (`if T then ...
-end`) are skipped. `code.lua` and `closure.lua` pass fully with
-`RILUA_TEST_LIB=1`.
+end`) are skipped. All four pass with `RILUA_TEST_LIB=1`.
 
 #### Test Files
 
@@ -425,7 +438,7 @@ Test coverage is measured by:
 
 1. **Feature coverage** -- which Lua 5.1.1 features are implemented
    and tested (tracked in CHANGELOG.md).
-2. **PUC-Rio test suite progress** -- N of 24 official test files
+2. **PUC-Rio test suite progress** -- 23 of 23 official test files
    passing (tracked in CI).
 3. **Oracle comparison count** -- number of Lua snippets verified
    against PUC-Rio output.


### PR DESCRIPTION
## Summary

- **architecture.md**: Remove broken links to 11 deleted detail files, add 11 missing source files to module listing (`conversion.rs`, `handles.rs`, `platform.rs`, `vm/dump.rs`, `vm/undump.rs`, `vm/listing.rs`, `vm/metatable.rs`, `vm/debug_info.rs`, `stdlib/testlib.rs`, `bin/`)
- **testing.md**: Update T module from 9 to 25 functions, remove incorrect "not implemented" note for `T.testC`/`T.checkmemory`/`T.totalmem`, update test counts to 1316, fix coverage tracking "N of 24" to "23 of 23"
- **README.md**: Update `all.lua` timing from ~17s to ~3s after 4 optimization phases
- **CHANGELOG.md**: Add phase 4 SoA arena sweep optimization under `[Unreleased]`

## Test plan

- [x] Full quality gate passes (`fmt`, `clippy`, `test`, `doc`)