### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/wowemulation-dev/rilua/compare/v0.1.4...v0.1.5) - 2026-02-19
+
+### Documentation
+
+- sync documentation with current code state
+
 ## [0.1.4](https://github.com/wowemulation-dev/rilua/compare/v0.1.3...v0.1.4) - 2026-02-16
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "flamegraph",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/wowemulation-dev/rilua/compare/v0.1.4...v0.1.5) - 2026-02-19

### Documentation

- sync documentation with current code state
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).