### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/wowemulation-dev/rilua/compare/v0.1.5...v0.1.6) - 2026-02-20
+
+### Added
+
+- cross-platform signal handling with raw FFI, no libc dependency
+
+### Documentation
+
+- add embedding example and examples README
+- add changelog entry for cross-platform signal handling
+- sync documentation with signal handling changes
+
 ### Added
 
 - Cross-platform SIGINT handling (Unix via raw `signal()` FFI, Windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "flamegraph",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/wowemulation-dev/rilua/compare/v0.1.5...v0.1.6) - 2026-02-20

### Added

- cross-platform signal handling with raw FFI, no libc dependency

### Documentation

- add embedding example and examples README
- add changelog entry for cross-platform signal handling
- sync documentation with signal handling changes

### Added

- Cross-platform SIGINT handling (Unix via raw `signal()` FFI, Windows
  via `SetConsoleCtrlHandler`). Second Ctrl+C terminates immediately.
  No-op on other platforms (e.g. WASM).
- `set_interrupted()` and `clear_interrupted()` public API for embedders
  to integrate custom interrupt sources
- `examples/run_file.rs` embedding example with `hello.lua` sample script

### Changed

- Interrupt flag is unconditional (`AtomicBool` with `Relaxed` ordering,
  no `#[cfg]` gates). Compiles on all targets including wasm32.
- `INTERRUPTED` static is now private; `check_interrupted()` is `pub(crate)`

### Removed

- `libc` crate dependency (replaced with raw `extern "C"` FFI, restoring
  zero external runtime dependencies)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).