### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/wowemulation-dev/rilua/compare/v0.1.6...v0.1.7) - 2026-02-20
+
+### Added
+
+- implement package.loadlib with rilua-native module ABI
+
 ## [0.1.6](https://github.com/wowemulation-dev/rilua/compare/v0.1.5...v0.1.6) - 2026-02-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "flamegraph",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/wowemulation-dev/rilua/compare/v0.1.6...v0.1.7) - 2026-02-20

### Added

- implement package.loadlib with rilua-native module ABI
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).