### PR TITLE
chore: add CONTRIBUTING.md, benchmarks, and runnable doc tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,245 @@
+# Contributing to rilua
+
+Thank you for considering contributing to rilua. We welcome community
+contributions. This document provides guidelines and instructions to make the
+contribution process smooth and effective for everyone.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+  - [Set Up Your Environment](#set-up-your-environment)
+  - [Find Issues to Work On](#find-issues-to-work-on)
+- [Making Contributions](#making-contributions)
+  - [Create a Branch](#create-a-branch)
+  - [Make Your Changes](#make-your-changes)
+  - [Test Your Changes](#test-your-changes)
+  - [Submit a Pull Request](#submit-a-pull-request)
+- [Coding Guidelines](#coding-guidelines)
+- [Documentation](#documentation)
+- [Community](#community)
+- [Recognition](#recognition)
+
+## Code of Conduct
+
+This project and everyone participating in it follows our community guidelines.
+By participating, you are expected to be respectful and constructive.
+Please report unacceptable behavior to [the maintainer](mailto:daniel@kogito.network).
+
+## Getting Started
+
+### Set Up Your Environment
+
+1. **Fork the repository**: Click the "Fork" button at the top right of the
+   [repository page](https://github.com/wowemulation-dev/rilua).
+
+2. **Clone your fork**:
+
+   ```bash
+   git clone https://github.com/your-username/rilua.git
+   cd rilua
+   ```
+
+3. **Set up the upstream remote**:
+
+   ```bash
+   git remote add upstream https://github.com/wowemulation-dev/rilua.git
+   ```
+
+4. **Install Rust and tools**:
+   - Install [Rust](https://www.rust-lang.org/tools/install) (MSRV: 1.92.0)
+   - Install [Mise](https://mise.jdx.dev/) for development tools (optional):
+     `mise install` will set up the correct Rust toolchain and tools
+   - Run `cargo build` to verify the project builds
+
+### Find Issues to Work On
+
+- Check the [Issues](https://github.com/wowemulation-dev/rilua/issues) tab
+  for tasks labeled "good first issue" or "help wanted"
+- Review the documentation in the `docs/` directory for planned features
+
+## Making Contributions
+
+### Create a Branch
+
+```bash
+# Make sure you're up to date
+git checkout main
+git pull upstream main
+
+# Create a new branch
+git checkout -b my-feature-branch
+```
+
+Name your branch descriptively, e.g., `feat/add-userdata-api` or
+`fix/gc-sweep-crash`.
+
+### Make Your Changes
+
+1. **Code**: Implement your changes following our
+   [Coding Guidelines](#coding-guidelines)
+2. **Tests**: Add or update tests for your changes
+3. **Documentation**: Update documentation as needed
+
+### Test Your Changes
+
+Before submitting your changes, run the quality gate:
+
+```bash
+# Format your code
+cargo fmt
+
+# Check for common issues (strict clippy)
+cargo clippy --all-targets
+
+# Run tests
+cargo test
+
+# Check documentation builds without warnings
+cargo doc --no-deps
+```
+
+Or run all checks at once with Mise:
+
+```bash
+mise run quality-gate
+```
+
+If you've added a new feature, consider adding a benchmark:
+
+```bash
+cargo bench
+```
+
+If your changes affect the `dynmod` feature, also test with:
+
+```bash
+cargo clippy --all-targets --features dynmod
+cargo test --features dynmod
+```
+
+#### Continuous Integration
+
+The CI pipeline runs on all pull requests and pushes to main. It has 5
+functional jobs:
+
+1. **Changed Files Detection**: Identifies what changed to scope checks.
+
+2. **Quick Checks** (runs first, fails fast):
+   - Code formatting (`cargo fmt -- --check`)
+   - Compilation check (`cargo check --all-targets`)
+   - Linting (`cargo clippy --all-targets`)
+
+3. **Tests** (MSRV 1.92.0 + stable):
+   - `cargo nextest run --profile ci` on both Rust versions
+
+4. **Documentation**:
+   - `cargo doc --no-deps` with `RUSTDOCFLAGS=-D warnings`
+
+5. **PUC-Rio Compatibility** (runs after CI passes):
+   - Runs the official Lua 5.1.1 test suite (23 tests) against rilua
+
+### Submit a Pull Request
+
+1. **Push your changes**:
+
+   ```bash
+   git push origin my-feature-branch
+   ```
+
+2. **Create a Pull Request**: Go to the
+   [repository page](https://github.com/wowemulation-dev/rilua) and click
+   "New Pull Request"
+
+3. **Describe your changes**:
+   - Provide a clear title following
+     [Conventional Commits](https://www.conventionalcommits.org/) format
+   - Explain what you've changed and why
+   - Reference any related issues (e.g., "Fixes #42")
+   - Include any special instructions for testing
+
+4. **Respond to feedback**: Maintainers may suggest changes to your PR.
+   Discuss and make any necessary updates.
+
+## Coding Guidelines
+
+- Follow Rust's official
+  [style guide](https://doc.rust-lang.org/1.0.0/style/README.html)
+- Use meaningful variable and function names
+- Write comments for non-obvious logic (explain "why", not "what")
+- Keep functions focused on a single responsibility
+- Use `Result` and `Option` for error handling -- no `unwrap()` or `expect()`
+  in library code (these are enforced by clippy lints)
+- All `unsafe` code must be feature-gated or in `src/platform.rs` with
+  `#[allow(unsafe_code)]` and SAFETY comments
+- Zero external runtime dependencies -- do not add crate dependencies
+  to `[dependencies]` without discussion
+
+### Commit Messages
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/)
+specification:
+
+- `feat:` for new features
+- `fix:` for bug fixes
+- `perf:` for performance improvements
+- `refactor:` for code changes that neither fix bugs nor add features
+- `docs:` for documentation changes
+- `test:` for test changes
+- `chore:` for maintenance tasks
+
+## Documentation
+
+- **Code Comments**: Document functions and non-obvious logic
+- **Examples**: Add examples for new features in the `examples/` directory
+- **README**: Update the README if your changes add new features or change
+  existing functionality
+- **Rustdoc**: Add documentation comments (`///`) to public API elements
+  with runnable examples where practical
+
+## Community
+
+- **Ask questions**: If you're unsure about something, open an issue
+- **Be respectful**: Always be kind and constructive in communications
+
+## Recognition
+
+All contributions are valued. Contributors will be mentioned in release notes
+when their contributions are included.
+
+---
+
+## First-Time Contributors
+
+New to open source or Rust? Here are tips to get started:
+
+### Understanding the Codebase
+
+rilua is a Lua 5.1.1 interpreter. The main components are:
+
+- `src/compiler/` -- Lexer, parser, AST, bytecode compiler
+- `src/vm/` -- Virtual machine, instruction dispatch, GC, tables, strings
+- `src/stdlib/` -- Standard library (base, string, table, math, io, os, etc.)
+- `src/platform.rs` -- Platform-specific FFI (centralized)
+- `src/lib.rs` -- Public Rust embedding API
+
+See `docs/architecture.md` for a detailed overview.
+
+### Tips
+
+1. **Start small**: Fix a typo, improve documentation, or tackle a "good first
+   issue"
+2. **Read the tests**: The `tests/` directory and PUC-Rio test suite
+   (`lua-5.1-tests/`) show expected behavior
+3. **Reference PUC-Rio**: The original C source is in `lua-5.1.1/` for
+   cross-referencing
+
+### Learning Resources
+
+- [Rust Book](https://doc.rust-lang.org/book/)
+- [Lua 5.1 Reference Manual](https://www.lua.org/manual/5.1/manual.html)
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+
+---
+
+Thank you for contributing to rilua.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +116,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -215,6 +236,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +262,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -331,6 +385,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,10 +430,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dashmap"
@@ -399,6 +514,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elsa"
@@ -579,6 +700,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +727,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -867,10 +1005,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1002,6 +1160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1190,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opener"
@@ -1096,6 +1269,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1257,6 +1458,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,10 +1518,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -1356,6 +1600,7 @@ dependencies = [
 name = "rilua"
 version = "0.1.7"
 dependencies = [
+ "criterion",
  "flamegraph",
 ]
 
@@ -1453,6 +1698,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1708,6 +1962,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +2164,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,4 +80,9 @@ cargo_common_metadata = { level = "allow", priority = 1 }
 redundant_else = { level = "allow", priority = 1 }
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 flamegraph = "0.6"
+
+[[bench]]
+name = "interpreter"
+harness = false

--- a/benches/interpreter.rs
+++ b/benches/interpreter.rs
@@ -1,0 +1,402 @@
+//! Criterion benchmarks for rilua interpreter hot paths.
+//!
+//! Run with: `cargo bench`
+
+#![allow(clippy::expect_used)]
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use rilua::compiler::codegen;
+use rilua::{Lua, StdLib, Val};
+
+// ---------------------------------------------------------------------------
+// State creation
+// ---------------------------------------------------------------------------
+
+fn bench_state_creation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("state_creation");
+
+    group.bench_function("new_empty", |b| {
+        b.iter(|| {
+            let lua = Lua::new_empty();
+            black_box(lua);
+        });
+    });
+
+    group.bench_function("new_with_base", |b| {
+        b.iter(|| {
+            let lua = Lua::new_with(StdLib::BASE).expect("new_with failed");
+            black_box(lua);
+        });
+    });
+
+    group.bench_function("new_full", |b| {
+        b.iter(|| {
+            let lua = Lua::new().expect("new failed");
+            black_box(lua);
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Compilation
+// ---------------------------------------------------------------------------
+
+fn bench_compilation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compilation");
+
+    // Minimal script.
+    group.bench_function("compile_minimal", |b| {
+        b.iter(|| {
+            let proto = codegen::compile(black_box(b"return 1"), "bench");
+            black_box(proto).expect("compile failed");
+        });
+    });
+
+    // Arithmetic loop.
+    let loop_src = b"local s = 0; for i = 1, 1000 do s = s + i end; return s";
+    group.bench_function("compile_loop", |b| {
+        b.iter(|| {
+            let proto = codegen::compile(black_box(loop_src), "bench");
+            black_box(proto).expect("compile failed");
+        });
+    });
+
+    // Function definitions.
+    let funcs_src = br"
+        local function fib(n)
+            if n < 2 then return n end
+            return fib(n - 1) + fib(n - 2)
+        end
+        local function fact(n)
+            if n <= 1 then return 1 end
+            return n * fact(n - 1)
+        end
+        return fib(10) + fact(10)
+    ";
+    group.bench_function("compile_functions", |b| {
+        b.iter(|| {
+            let proto = codegen::compile(black_box(funcs_src), "bench");
+            black_box(proto).expect("compile failed");
+        });
+    });
+
+    // Table-heavy code.
+    let table_src = br#"
+        local t = {}
+        for i = 1, 100 do
+            t[i] = { x = i, y = i * 2, name = "item" .. i }
+        end
+        local s = 0
+        for i = 1, #t do s = s + t[i].x + t[i].y end
+        return s
+    "#;
+    group.bench_function("compile_tables", |b| {
+        b.iter(|| {
+            let proto = codegen::compile(black_box(table_src), "bench");
+            black_box(proto).expect("compile failed");
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// VM execution
+// ---------------------------------------------------------------------------
+
+fn bench_vm_execution(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vm_execution");
+
+    // Arithmetic loop.
+    group.bench_function("loop_sum_1k", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE).expect("new failed");
+        b.iter(|| {
+            lua.exec(black_box("local s = 0; for i = 1, 1000 do s = s + i end"))
+                .expect("exec failed");
+        });
+    });
+
+    // Recursive fibonacci.
+    group.bench_function("fib_20", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE).expect("new failed");
+        lua.exec("function fib(n) if n < 2 then return n end return fib(n-1) + fib(n-2) end")
+            .expect("define fib failed");
+        b.iter(|| {
+            lua.exec(black_box("fib(20)")).expect("fib failed");
+        });
+    });
+
+    // String concatenation.
+    group.bench_function("string_concat_100", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE | StdLib::STRING).expect("new failed");
+        b.iter(|| {
+            lua.exec(black_box(
+                "local s = ''; for i = 1, 100 do s = s .. 'x' end",
+            ))
+            .expect("concat failed");
+        });
+    });
+
+    // Table construction and access.
+    group.bench_function("table_build_1k", |b| {
+        let mut lua =
+            Lua::new_with(StdLib::BASE | StdLib::TABLE).expect("new failed");
+        b.iter(|| {
+            lua.exec(black_box(
+                "local t = {}; for i = 1, 1000 do t[i] = i end; local s = 0; for i = 1, 1000 do s = s + t[i] end",
+            ))
+            .expect("table failed");
+        });
+    });
+
+    // Function calls (closure creation + upvalue access).
+    group.bench_function("closures_100", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE).expect("new failed");
+        b.iter(|| {
+            lua.exec(black_box(
+                r"
+                local fns = {}
+                for i = 1, 100 do
+                    local x = i
+                    fns[i] = function() return x end
+                end
+                local s = 0
+                for i = 1, 100 do s = s + fns[i]() end
+                ",
+            ))
+            .expect("closures failed");
+        });
+    });
+
+    // Method dispatch (metatables).
+    group.bench_function("metatable_index_1k", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE).expect("new failed");
+        lua.exec(
+            r"
+            local mt = { __index = function(t, k) return k end }
+            G_proxy = setmetatable({}, mt)
+            ",
+        )
+        .expect("setup failed");
+        b.iter(|| {
+            lua.exec(black_box(
+                "local p = G_proxy; local s = 0; for i = 1, 1000 do s = s + p[i] end",
+            ))
+            .expect("meta failed");
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Garbage collection
+// ---------------------------------------------------------------------------
+
+fn bench_gc(c: &mut Criterion) {
+    let mut group = c.benchmark_group("gc");
+
+    // Full GC cycle on a state with many allocations.
+    group.bench_function("collect_10k_tables", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE).expect("new failed");
+        lua.gc_stop();
+        // Pre-allocate many tables.
+        lua.exec("G_tables = {}; for i = 1, 10000 do G_tables[i] = {i, i+1, i+2} end")
+            .expect("alloc failed");
+        b.iter(|| {
+            lua.gc_collect().expect("gc failed");
+        });
+    });
+
+    // GC with dead objects (allocation churn).
+    group.bench_function("churn_alloc_collect", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE).expect("new failed");
+        b.iter(|| {
+            lua.gc_stop();
+            lua.exec(black_box(
+                "for i = 1, 1000 do local t = {i, i+1}; local s = 'str' .. i end",
+            ))
+            .expect("churn failed");
+            lua.gc_collect().expect("gc failed");
+        });
+    });
+
+    // Incremental GC stepping.
+    group.bench_function("step_incremental", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE).expect("new failed");
+        lua.gc_stop();
+        lua.exec("G_data = {}; for i = 1, 5000 do G_data[i] = {x=i} end")
+            .expect("setup failed");
+        b.iter(|| {
+            let _ = lua.gc_step(black_box(1024));
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// String interning
+// ---------------------------------------------------------------------------
+
+fn bench_string_interning(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string_interning");
+
+    // Intern unique strings.
+    group.bench_function("intern_unique_1k", |b| {
+        let mut lua = Lua::new_empty();
+        b.iter(|| {
+            for i in 0..1000 {
+                let s = format!("unique_string_{i}");
+                black_box(lua.create_string(s.as_bytes()));
+            }
+        });
+    });
+
+    // Intern duplicate strings (dedup hit).
+    group.bench_function("intern_dedup_1k", |b| {
+        let mut lua = Lua::new_empty();
+        // Pre-intern the strings.
+        for i in 0..100 {
+            let s = format!("dedup_{i}");
+            lua.create_string(s.as_bytes());
+        }
+        let keys: Vec<String> = (0..100).map(|i| format!("dedup_{i}")).collect();
+        b.iter(|| {
+            for key in &keys {
+                black_box(lua.create_string(key.as_bytes()));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Table operations (via Lua API)
+// ---------------------------------------------------------------------------
+
+fn bench_table_ops(c: &mut Criterion) {
+    let mut group = c.benchmark_group("table_ops");
+
+    // Integer key insert via raw_set.
+    group.bench_function("raw_set_int_1k", |b| {
+        let mut lua = Lua::new_empty();
+        b.iter(|| {
+            let table = lua.create_table();
+            for i in 1..=1000 {
+                lua.table_raw_set(&table, Val::Num(f64::from(i)), Val::Num(f64::from(i)))
+                    .expect("raw_set failed");
+            }
+            black_box(table);
+        });
+    });
+
+    // String key insert via raw_set.
+    group.bench_function("raw_set_str_1k", |b| {
+        let mut lua = Lua::new_empty();
+        let keys: Vec<Val> = (0..1000)
+            .map(|i| {
+                let s = format!("key_{i}");
+                lua.create_string(s.as_bytes())
+            })
+            .collect();
+        b.iter(|| {
+            let table = lua.create_table();
+            for (i, key) in keys.iter().enumerate() {
+                lua.table_raw_set(&table, *key, Val::Num(i as f64))
+                    .expect("raw_set failed");
+            }
+            black_box(table);
+        });
+    });
+
+    // Mixed table operations in Lua.
+    group.bench_function("mixed_ops_lua", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE | StdLib::TABLE).expect("new failed");
+        b.iter(|| {
+            lua.exec(black_box(
+                r#"
+                local t = {}
+                for i = 1, 500 do t[i] = i end
+                for i = 1, 500 do t["k" .. i] = i end
+                local s = 0
+                for i = 1, 500 do s = s + t[i] end
+                for i = 1, 500 do s = s + t["k" .. i] end
+                "#,
+            ))
+            .expect("mixed ops failed");
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end
+// ---------------------------------------------------------------------------
+
+fn bench_end_to_end(c: &mut Criterion) {
+    let mut group = c.benchmark_group("end_to_end");
+
+    // Compile + execute a realistic script.
+    group.bench_function("compile_and_run", |b| {
+        b.iter(|| {
+            let mut lua = Lua::new().expect("new failed");
+            lua.exec(black_box(
+                r"
+                local function map(t, f)
+                    local r = {}
+                    for i = 1, #t do r[i] = f(t[i]) end
+                    return r
+                end
+                local data = {}
+                for i = 1, 100 do data[i] = i end
+                local doubled = map(data, function(x) return x * 2 end)
+                local sum = 0
+                for i = 1, #doubled do sum = sum + doubled[i] end
+                ",
+            ))
+            .expect("exec failed");
+        });
+    });
+
+    // Coroutine create/resume/yield cycle.
+    group.bench_function("coroutine_cycle", |b| {
+        let mut lua = Lua::new_with(StdLib::BASE | StdLib::COROUTINE).expect("new failed");
+        b.iter(|| {
+            lua.exec(black_box(
+                r#"
+                local co = coroutine.create(function()
+                    for i = 1, 50 do
+                        coroutine.yield(i)
+                    end
+                    return 0
+                end)
+                local s = 0
+                while coroutine.status(co) ~= "dead" do
+                    local ok, v = coroutine.resume(co)
+                    if ok then s = s + v end
+                end
+                "#,
+            ))
+            .expect("coroutine failed");
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_state_creation,
+    bench_compilation,
+    bench_vm_execution,
+    bench_gc,
+    bench_string_interning,
+    bench_table_ops,
+    bench_end_to_end,
+);
+criterion_main!(benches);

--- a/deny.toml
+++ b/deny.toml
@@ -11,7 +11,7 @@ targets = [
     "aarch64-apple-darwin",
     "x86_64-pc-windows-msvc",
 ]
-# Exclude dev-dependencies from checks (only flamegraph)
+# Exclude dev-dependencies from checks (criterion, flamegraph)
 exclude-dev = true
 
 [output]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,15 @@
 //!
 //! # Usage
 //!
-//! ```ignore
-//! use rilua::{Lua, StdLib};
+//! ```rust
+//! use rilua::Lua;
 //!
-//! let mut lua = Lua::new()?;
-//! lua.exec("print(1 + 2)")?;
+//! let mut lua = Lua::new().unwrap();
+//! lua.exec("print(1 + 2)").unwrap();
 //!
-//! lua.set_global("x", 42.0)?;
-//! let x: f64 = lua.global("x")?;
+//! lua.set_global("x", 42.0).unwrap();
+//! let x: f64 = lua.global("x").unwrap();
+//! assert_eq!(x, 42.0);
 //! ```
 
 pub mod compiler;
@@ -129,8 +130,10 @@ impl Lua {
 
     /// Creates a new Lua state with selected standard libraries.
     ///
-    /// ```ignore
-    /// let lua = Lua::new_with(StdLib::BASE | StdLib::STRING)?;
+    /// ```rust
+    /// use rilua::{Lua, StdLib};
+    ///
+    /// let lua = Lua::new_with(StdLib::BASE | StdLib::STRING).unwrap();
     /// ```
     pub fn new_with(libs: StdLib) -> LuaResult<Self> {
         let mut lua = Self {

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -29,8 +29,10 @@ use crate::vm::value::{Userdata, Val};
 ///
 /// Combines with `|` for ergonomic selective loading:
 ///
-/// ```ignore
-/// let lua = Lua::new_with(StdLib::BASE | StdLib::STRING | StdLib::TABLE)?;
+/// ```rust
+/// use rilua::{Lua, StdLib};
+///
+/// let lua = Lua::new_with(StdLib::BASE | StdLib::STRING | StdLib::TABLE).unwrap();
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StdLib(u16);


### PR DESCRIPTION
## Summary

- Add CONTRIBUTING.md with development workflow, quality gate, CI description, coding guidelines, and codebase overview (adapted from cascette-rs)
- Add criterion benchmarks (`benches/interpreter.rs`) with 20 benchmarks across 7 groups: state creation, compilation, VM execution, GC, string interning, table operations, end-to-end
- Convert 3 doc examples from `ignore` to runnable doc tests (`src/lib.rs`, `src/stdlib/mod.rs`)
- Add criterion 0.5 as dev-dependency

## Related issues

- #16 (advanced embedding example)
- #17 (property-based fuzzing)

## Test plan

- [ ] `cargo test` passes (including 3 new doc tests)
- [ ] `cargo bench --bench interpreter -- --test` dry-runs all benchmarks
- [ ] `cargo clippy --all-targets` produces 0 warnings
- [ ] `cargo doc --no-deps` produces 0 warnings
- [ ] `cargo fmt -- --check` passes