### PR TITLE
fix: link ucrt on Windows MSVC for libc FFI symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Link `ucrt` on Windows MSVC for libc FFI symbols (`gmtime_s`, `localtime_s`, `fprintf`, `fscanf`)
+
 ## [0.1.9](https://github.com/wowemulation-dev/rilua/compare/v0.1.8...v0.1.9) - 2026-02-20
 
 ### Added

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -28,6 +28,7 @@ pub(crate) enum LibcFile {}
 // ---------------------------------------------------------------------------
 
 #[allow(unsafe_code)]
+#[cfg_attr(target_env = "msvc", link(name = "ucrt"))]
 unsafe extern "C" {
     pub(crate) fn fopen(filename: *const u8, mode: *const u8) -> *mut LibcFile;
     pub(crate) fn fclose(file: *mut LibcFile) -> i32;
@@ -190,6 +191,7 @@ unsafe extern "C" {
 
 #[cfg(target_os = "windows")]
 #[allow(unsafe_code)]
+#[link(name = "ucrt")]
 unsafe extern "C" {
     fn __acrt_iob_func(index: u32) -> *mut LibcFile;
 }
@@ -252,6 +254,7 @@ unsafe extern "C" {
 
 #[cfg(target_os = "windows")]
 #[allow(unsafe_code)]
+#[link(name = "ucrt")]
 unsafe extern "C" {
     #[link_name = "_popen"]
     fn popen(command: *const u8, r#type: *const u8) -> *mut LibcFile;
@@ -284,6 +287,7 @@ unsafe extern "C" {
 
 #[cfg(target_os = "windows")]
 #[allow(unsafe_code)]
+#[link(name = "ucrt")]
 unsafe extern "C" {
     // Windows reverses parameter order and returns errno_t.
     fn localtime_s(result: *mut Tm, timep: *const TimeT) -> i32;


### PR DESCRIPTION
## Summary

- Add `#[link(name = "ucrt")]` to extern blocks declaring C runtime functions on Windows MSVC
- Fixes unresolved symbols: `gmtime_s`, `localtime_s`, `fprintf`, `fscanf`

Closes #21

## Test plan

- [ ] CI passes on Linux (no change in behavior)
- [ ] Release binary workflow succeeds for `x86_64-pc-windows-msvc` on next tag