### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/wowemulation-dev/rilua/compare/v0.1.9...v0.1.10) - 2026-02-20
+
+### Fixed
+
+- link ucrt on Windows MSVC for libc FFI symbols
+
 ### Fixed
 
 - Link `ucrt` on Windows MSVC for libc FFI symbols (`gmtime_s`, `localtime_s`, `fprintf`, `fscanf`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "criterion",
  "flamegraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.10](https://github.com/wowemulation-dev/rilua/compare/v0.1.9...v0.1.10) - 2026-02-20

### Fixed

- link ucrt on Windows MSVC for libc FFI symbols

### Fixed

- Link `ucrt` on Windows MSVC for libc FFI symbols (`gmtime_s`, `localtime_s`, `fprintf`, `fscanf`)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).