### PR TITLE
fix: correct MSVC CRT symbol names and link libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Link `legacy_stdio_definitions` for `fprintf`/`fscanf` on MSVC (inline since VS2015)
+- Use `_gmtime64_s`/`_localtime64_s` symbol names on MSVC (header wrappers don't exist in ucrtbase.dll)
+
 ## [0.1.10](https://github.com/wowemulation-dev/rilua/compare/v0.1.9...v0.1.10) - 2026-02-20
 
 ### Fixed

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -27,8 +27,12 @@ pub(crate) enum LibcFile {}
 // Portable C functions (identical on all platforms)
 // ---------------------------------------------------------------------------
 
+// On MSVC, `fprintf`/`fscanf` are inline functions in headers since VS2015.
+// The non-inline definitions live in `legacy_stdio_definitions.lib`.
+// All other C runtime functions are in `ucrt.lib`.
 #[allow(unsafe_code)]
 #[cfg_attr(target_env = "msvc", link(name = "ucrt"))]
+#[cfg_attr(target_env = "msvc", link(name = "legacy_stdio_definitions"))]
 unsafe extern "C" {
     pub(crate) fn fopen(filename: *const u8, mode: *const u8) -> *mut LibcFile;
     pub(crate) fn fclose(file: *mut LibcFile) -> i32;
@@ -290,7 +294,11 @@ unsafe extern "C" {
 #[link(name = "ucrt")]
 unsafe extern "C" {
     // Windows reverses parameter order and returns errno_t.
+    // On 64-bit MSVC, `localtime_s`/`gmtime_s` are header-level wrappers
+    // that resolve to `_localtime64_s`/`_gmtime64_s` in ucrtbase.dll.
+    #[cfg_attr(target_env = "msvc", link_name = "_localtime64_s")]
     fn localtime_s(result: *mut Tm, timep: *const TimeT) -> i32;
+    #[cfg_attr(target_env = "msvc", link_name = "_gmtime64_s")]
     fn gmtime_s(result: *mut Tm, timep: *const TimeT) -> i32;
 }
 


### PR DESCRIPTION
## Summary

- Link `legacy_stdio_definitions.lib` on MSVC for `fprintf`/`fscanf` (inline in headers since VS2015, non-inline symbols in this library)
- Use `#[link_name = "_gmtime64_s"]` and `#[link_name = "_localtime64_s"]` on MSVC (`gmtime_s`/`localtime_s` are header wrappers that don't exist as symbols in `ucrtbase.dll`)

The v0.1.10 fix correctly added `ucrt.lib` to the link line, but the 4 unresolved symbols had different root causes:
- `fprintf`/`fscanf` → not in `ucrt.lib` at all, need `legacy_stdio_definitions.lib`
- `gmtime_s`/`localtime_s` → exported as `_gmtime64_s`/`_localtime64_s` in the DLL

Fixes #21 (supersedes partial fix in v0.1.10)

## Test plan

- [ ] CI passes on all platforms (Linux, macOS check compilation)
- [ ] Release Binaries workflow succeeds for x86_64-pc-windows-msvc after tagging