### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/wowemulation-dev/rilua/compare/v0.1.10...v0.1.11) - 2026-02-20
+
+### Fixed
+
+- use correct MSVC symbol names and link libraries for CRT functions
+
 ### Fixed
 
 - Link `legacy_stdio_definitions` for `fprintf`/`fscanf` on MSVC (inline since VS2015)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "criterion",
  "flamegraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.11](https://github.com/wowemulation-dev/rilua/compare/v0.1.10...v0.1.11) - 2026-02-20

### Fixed

- use correct MSVC symbol names and link libraries for CRT functions

### Fixed

- Link `legacy_stdio_definitions` for `fprintf`/`fscanf` on MSVC (inline since VS2015)
- Use `_gmtime64_s`/`_localtime64_s` symbol names on MSVC (header wrappers don't exist in ucrtbase.dll)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).