### PR TITLE
chore: release v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/wowemulation-dev/rilua/compare/v0.1.12...v0.1.13) - 2026-02-20
+
+### Documentation
+
+- update sponsor link and tailor .editorconfig
+- standardize README badges
+- add performance documentation and gitignore flamegraphs
+- fix stale test counts, loadlib description, and contradictions
+
 ## [0.1.12](https://github.com/wowemulation-dev/rilua/compare/v0.1.11...v0.1.12) - 2026-02-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "criterion",
  "flamegraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.12 -> 0.1.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.13](https://github.com/wowemulation-dev/rilua/compare/v0.1.12...v0.1.13) - 2026-02-20

### Documentation

- update sponsor link and tailor .editorconfig
- standardize README badges
- add performance documentation and gitignore flamegraphs
- fix stale test counts, loadlib description, and contradictions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).