### PR TITLE
chore: release v0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.21](https://github.com/wowemulation-dev/rilua/compare/v0.1.20...v0.1.21) - 2026-02-27
+
+### Added
+
+- add multi-implementation benchmark script
+
+### Documentation
+
+- add lua-rs (CppCXY) to implementation comparison
+- update comparison with measured benchmark data
+- add "Why rilua" section to README
+- add comparison with PUC-Rio, mlua, and Luau
+
+### Performance
+
+- add #[inline] to table lookup hot paths
+
 ## [0.1.20](https://github.com/wowemulation-dev/rilua/compare/v0.1.19...v0.1.20) - 2026-02-25
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "criterion",
  "flamegraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.20 -> 0.1.21

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.21](https://github.com/wowemulation-dev/rilua/compare/v0.1.20...v0.1.21) - 2026-02-27

### Added

- add multi-implementation benchmark script

### Documentation

- add lua-rs (CppCXY) to implementation comparison
- update comparison with measured benchmark data
- add "Why rilua" section to README
- add comparison with PUC-Rio, mlua, and Luau

### Performance

- add #[inline] to table lookup hot paths
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).