### PR TITLE
extract impl Lua block into traits

### DIFF
--- a/examples/advanced_embedding.rs
+++ b/examples/advanced_embedding.rs
@@ -16,8 +16,7 @@
 use rilua::vm::state::LuaState;
 use rilua::vm::value::Userdata;
 use rilua::{
-    FromLua, Function, Lua, LuaError, LuaResult, RuntimeError, StdLib, Table, Thread, Val,
-    runtime_error,
+    FromLua, Function, Lua, LuaApiMut, LuaError, LuaResult, RuntimeError, StdLib, Table, Thread, Val, runtime_error
 };
 
 // ---------------------------------------------------------------------------

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,245 @@
+//! Public API traits for Lua operations.
+//!
+//! Provides `LuaApi` for immutable operations and `LuaApiMut` for mutable operations.
+
+use std::any::Any;
+use std::rc::Rc;
+
+use crate::conversion::{FromLua, IntoLua};
+use crate::error::{LuaError, LuaResult, RuntimeError};
+use crate::handles::{AnyUserData, Function, Table};
+use crate::vm::closure::{Closure, LuaClosure, RustClosure, RustFn};
+use crate::vm::state::LuaState;
+use crate::vm::value::Val;
+
+/// Read-only API trait for Lua operations.
+///
+/// Provides immutable access to Lua state for operations that don't modify state.
+pub trait LuaApi {
+    /// Returns an immutable reference to the underlying `LuaState`.
+    fn state(&self) -> &LuaState;
+
+    /// Returns the total memory in use by Lua (in bytes).
+    fn gc_count(&self) -> usize {
+        self.state().gc.gc_state.total_bytes
+    }
+
+    /// Raw get on a table handle via the public API.
+    fn table_raw_get(&self, table: &Table, key: Val) -> LuaResult<Val> {
+        table.raw_get(self.state(), key)
+    }
+
+    /// Returns the raw length of a table (no `__len` metamethod).
+    fn table_raw_len(&self, table: &Table) -> i64 {
+        table.raw_len(self.state())
+    }
+}
+
+/// Mutable API trait for Lua operations.
+///
+/// Extends `LuaApi` with operations that require mutable access to state.
+pub trait LuaApiMut: LuaApi {
+    /// Returns a mutable reference to the underlying `LuaState`.
+    fn state_mut(&mut self) -> &mut LuaState;
+
+    // -----------------------------------------------------------------------
+    // Globals
+    // -----------------------------------------------------------------------
+
+    /// Gets a global variable, converting it to the requested Rust type.
+    fn global<V: FromLua>(&mut self, name: &str) -> LuaResult<V>
+    where
+        Self: Sized,
+    {
+        let val = self.get_global_val(name);
+        V::from_lua(val, self)
+    }
+
+    /// Sets a global variable from a Rust value.
+    fn set_global<V: IntoLua>(&mut self, name: &str, value: V) -> LuaResult<()>
+    where
+        Self: Sized,
+    {
+        let val = value.into_lua(self)?;
+        self.set_global_val(name, val)
+    }
+
+    /// Reads a value from the global table by name.
+    fn get_global_val(&mut self, name: &str) -> Val {
+        let state = self.state_mut();
+        let key_ref = state.gc.intern_string(name.as_bytes());
+        let Some(global_table) = state.gc.tables.get(state.global) else {
+            return Val::Nil;
+        };
+        global_table.get_str(key_ref, &state.gc.string_arena)
+    }
+
+    /// Sets a value in the global table by name.
+    fn set_global_val(&mut self, name: &str, val: Val) -> LuaResult<()> {
+        let state = self.state_mut();
+        let key_ref = state.gc.intern_string(name.as_bytes());
+        let key = Val::Str(key_ref);
+        let global = state.global;
+        let table = state.gc.tables.get_mut(global).ok_or_else(|| {
+            LuaError::Runtime(RuntimeError {
+                message: "global table not found".into(),
+                level: 0,
+                traceback: vec![],
+            })
+        })?;
+        table.raw_set(key, val, &state.gc.string_arena)
+    }
+
+    // -----------------------------------------------------------------------
+    // Table creation
+    // -----------------------------------------------------------------------
+
+    /// Allocates a new empty table and returns a handle.
+    fn create_table(&mut self) -> Table {
+        let state = self.state_mut();
+        let r = state.gc.alloc_table(crate::vm::table::Table::new());
+        Table(r)
+    }
+
+    // -----------------------------------------------------------------------
+    // Userdata creation
+    // -----------------------------------------------------------------------
+
+    /// Creates a new userdata containing `data` with no metatable.
+    fn create_userdata<T: Any>(&mut self, data: T) -> AnyUserData {
+        let state = self.state_mut();
+        let ud = crate::vm::value::Userdata::new(Box::new(data));
+        let r = state.gc.alloc_userdata(ud);
+        AnyUserData(r)
+    }
+
+    /// Creates a new userdata with a named, registry-cached metatable.
+    fn create_typed_userdata<T: Any>(
+        &mut self,
+        data: T,
+        type_name: &str,
+    ) -> LuaResult<AnyUserData> {
+        let state = self.state_mut();
+        let mt = crate::stdlib::new_metatable(state, type_name)?;
+        let ud = crate::vm::value::Userdata::with_metatable(Box::new(data), mt);
+        let r = state.gc.alloc_userdata(ud);
+        Ok(AnyUserData(r))
+    }
+
+    /// Creates or retrieves a named metatable for a userdata type.
+    fn create_userdata_metatable(&mut self, type_name: &str) -> LuaResult<Table> {
+        let state = self.state_mut();
+        let mt = crate::stdlib::new_metatable(state, type_name)?;
+        Ok(Table(mt))
+    }
+
+    // -----------------------------------------------------------------------
+    // Function registration
+    // -----------------------------------------------------------------------
+
+    /// Registers a Rust function as a global Lua function.
+    fn register_function(&mut self, name: &str, func: RustFn) -> LuaResult<()> {
+        let state = self.state_mut();
+        let closure = Closure::Rust(RustClosure::new(func, name));
+        let closure_ref = state.gc.alloc_closure(closure);
+        self.set_global_val(name, Val::Function(closure_ref))
+    }
+
+    // -----------------------------------------------------------------------
+    // GC control
+    // -----------------------------------------------------------------------
+
+    /// Runs a full garbage collection cycle.
+    fn gc_collect(&mut self) -> LuaResult<()> {
+        self.state_mut().full_gc()
+    }
+
+    /// Stops the garbage collector.
+    fn gc_stop(&mut self) {
+        self.state_mut().gc.gc_state.gc_threshold = usize::MAX;
+    }
+
+    /// Restarts the garbage collector.
+    fn gc_restart(&mut self) {
+        let state = self.state_mut();
+        state.gc.gc_state.gc_threshold = state.gc.gc_state.total_bytes;
+    }
+
+    /// Performs an incremental GC step.
+    fn gc_step(&mut self, step_size: i64) -> LuaResult<bool> {
+        self.state_mut().gc_step(step_size)
+    }
+
+    /// Sets the GC pause parameter (percentage). Returns the previous value.
+    fn gc_set_pause(&mut self, pause: u32) -> u32 {
+        let state = self.state_mut();
+        let old = state.gc.gc_state.gc_pause;
+        state.gc.gc_state.gc_pause = pause;
+        old
+    }
+
+    /// Sets the GC step multiplier. Returns the previous value.
+    fn gc_set_step_multiplier(&mut self, stepmul: u32) -> u32 {
+        let state = self.state_mut();
+        let old = state.gc.gc_state.gc_stepmul;
+        state.gc.gc_state.gc_stepmul = stepmul;
+        old
+    }
+
+    // -----------------------------------------------------------------------
+    // String creation
+    // -----------------------------------------------------------------------
+
+    /// Interns a byte string via the GC string table, returning `Val::Str`.
+    fn create_string(&mut self, s: &[u8]) -> Val {
+        let state = self.state_mut();
+        let str_ref = state.gc.intern_string(s);
+        Val::Str(str_ref)
+    }
+
+    // -----------------------------------------------------------------------
+    // Table operations
+    // -----------------------------------------------------------------------
+
+    /// Raw set on a table handle via the public API.
+    fn table_raw_set(&mut self, table: &Table, key: Val, value: Val) -> LuaResult<()> {
+        table.raw_set(self.state_mut(), key, value)
+    }
+
+    /// Sets a named Rust function on a table.
+    fn table_set_function(&mut self, table: &Table, name: &str, func: RustFn) -> LuaResult<()> {
+        let state = self.state_mut();
+        let key = Val::Str(state.gc.intern_string(name.as_bytes()));
+        let closure = Closure::Rust(RustClosure::new(func, name));
+        let closure_ref = state.gc.alloc_closure(closure);
+        table.raw_set(state, key, Val::Function(closure_ref))
+    }
+
+    // -----------------------------------------------------------------------
+    // Compilation and loading
+    // -----------------------------------------------------------------------
+
+    /// Compiles Lua source bytes (or loads a binary chunk) and returns a function handle.
+    fn load_bytes(&mut self, source: &[u8], name: &str) -> LuaResult<Function> {
+        let proto = crate::compile_or_undump(source, name)?;
+        let mut proto = Rc::try_unwrap(proto).unwrap_or_else(|rc| (*rc).clone());
+        let state = self.state_mut();
+        crate::patch_string_constants(&mut proto, &mut state.gc);
+        let proto = Rc::new(proto);
+
+        let num_upvalues = proto.num_upvalues as usize;
+        let mut lua_cl = LuaClosure::new(proto, state.global);
+        for _ in 0..num_upvalues {
+            let uv = crate::vm::closure::Upvalue::new_closed(Val::Nil);
+            let uv_ref = state.gc.alloc_upvalue(uv);
+            lua_cl.upvalues.push(uv_ref);
+        }
+        let closure_ref = state.gc.alloc_closure(Closure::Lua(lua_cl));
+        Ok(Function(closure_ref))
+    }
+
+    /// Compiles a Lua source string and returns a function handle.
+    fn load(&mut self, source: &str) -> LuaResult<Function> {
+        self.load_bytes(source.as_bytes(), "=(string)")
+    }
+}

--- a/src/bin/rilua.rs
+++ b/src/bin/rilua.rs
@@ -9,7 +9,7 @@ use std::env;
 use std::io::{self, BufRead, IsTerminal, Write};
 use std::process;
 
-use rilua::{Function, Lua, LuaError, StdLib, Val};
+use rilua::{Function, Lua, LuaApiMut, LuaError, StdLib, Val};
 
 // ---------------------------------------------------------------------------
 // SIGINT handling — raw FFI, no libc crate

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -5,7 +5,7 @@
 //! conversions. Standard implementations cover Rust primitives,
 //! strings, `Option<T>`, and tuple arities up to 8.
 
-use crate::Lua;
+use crate::api::{LuaApi, LuaApiMut};
 use crate::error::{LuaError, LuaResult, RuntimeError};
 use crate::handles::{AnyUserData, Function, Table, Thread};
 use crate::vm::value::Val;
@@ -16,19 +16,19 @@ use crate::vm::value::Val;
 
 /// Converts a Rust value into a Lua `Val`.
 ///
-/// Takes `&mut Lua` because operations like string interning require
+/// Takes `&mut L` where `L: LuaApiMut` because operations like string interning require
 /// mutable access to the GC.
 pub trait IntoLua {
     /// Performs the conversion.
-    fn into_lua(self, lua: &mut Lua) -> LuaResult<Val>;
+    fn into_lua<L: LuaApiMut>(self, lua: &mut L) -> LuaResult<Val>;
 }
 
 /// Extracts a Rust value from a Lua `Val`.
 ///
-/// Takes `&Lua` (immutable) because reading does not mutate state.
+/// Takes `&L` where `L: LuaApi` (immutable) because reading does not mutate state.
 pub trait FromLua: Sized {
     /// Performs the conversion.
-    fn from_lua(val: Val, lua: &Lua) -> LuaResult<Self>;
+    fn from_lua<L: LuaApi>(val: Val, lua: &L) -> LuaResult<Self>;
 }
 
 // ---------------------------------------------------------------------------
@@ -38,13 +38,13 @@ pub trait FromLua: Sized {
 /// Converts a Rust value into multiple Lua values.
 pub trait IntoLuaMulti {
     /// Performs the conversion.
-    fn into_lua_multi(self, lua: &mut Lua) -> LuaResult<Vec<Val>>;
+    fn into_lua_multi<L: LuaApiMut>(self, lua: &mut L) -> LuaResult<Vec<Val>>;
 }
 
 /// Extracts a Rust value from multiple Lua values.
 pub trait FromLuaMulti: Sized {
     /// Performs the conversion.
-    fn from_lua_multi(values: &[Val], lua: &Lua) -> LuaResult<Self>;
+    fn from_lua_multi<L: LuaApi>(values: &[Val], lua: &L) -> LuaResult<Self>;
 }
 
 // ---------------------------------------------------------------------------
@@ -52,13 +52,13 @@ pub trait FromLuaMulti: Sized {
 // ---------------------------------------------------------------------------
 
 impl IntoLua for Val {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(self)
     }
 }
 
 impl FromLua for Val {
-    fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
         Ok(val)
     }
 }
@@ -68,13 +68,13 @@ impl FromLua for Val {
 // ---------------------------------------------------------------------------
 
 impl IntoLua for () {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(Val::Nil)
     }
 }
 
 impl FromLua for () {
-    fn from_lua(_val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(_val: Val, _lua: &L) -> LuaResult<Self> {
         Ok(())
     }
 }
@@ -84,13 +84,13 @@ impl FromLua for () {
 // ---------------------------------------------------------------------------
 
 impl IntoLua for bool {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(Val::Bool(self))
     }
 }
 
 impl FromLua for bool {
-    fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
         match val {
             Val::Bool(b) => Ok(b),
             Val::Nil => Ok(false),
@@ -104,13 +104,13 @@ impl FromLua for bool {
 // ---------------------------------------------------------------------------
 
 impl IntoLua for f64 {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(Val::Num(self))
     }
 }
 
 impl FromLua for f64 {
-    fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
         match val {
             Val::Num(n) => Ok(n),
             _ => Err(conversion_error("number", val.type_name())),
@@ -119,13 +119,13 @@ impl FromLua for f64 {
 }
 
 impl IntoLua for f32 {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(Val::Num(f64::from(self)))
     }
 }
 
 impl FromLua for f32 {
-    fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
         match val {
             Val::Num(n) => Ok(n as Self),
             _ => Err(conversion_error("number", val.type_name())),
@@ -142,7 +142,7 @@ macro_rules! impl_integer_into_lua {
         $(
             impl IntoLua for $ty {
                 #[allow(clippy::cast_lossless, trivial_numeric_casts)]
-                fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+                fn into_lua<L: LuaApi>(self, _lua: &mut L) -> LuaResult<Val> {
                     Ok(Val::Num(self as f64))
                 }
             }
@@ -157,7 +157,7 @@ macro_rules! impl_integer_from_lua {
         $(
             impl FromLua for $ty {
                 #[allow(clippy::cast_lossless, trivial_numeric_casts)]
-                fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+                fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
                     match val {
                         Val::Num(n) => {
                             if n.fract() != 0.0 {
@@ -194,28 +194,28 @@ impl_integer_from_lua!(i8, i16, i32, i64, u8, u16, u32, u64, isize, usize);
 // ---------------------------------------------------------------------------
 
 impl IntoLua for String {
-    fn into_lua(self, lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, lua: &mut L) -> LuaResult<Val> {
         let r = lua.state_mut().gc.intern_string(self.as_bytes());
         Ok(Val::Str(r))
     }
 }
 
 impl IntoLua for &str {
-    fn into_lua(self, lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, lua: &mut L) -> LuaResult<Val> {
         let r = lua.state_mut().gc.intern_string(self.as_bytes());
         Ok(Val::Str(r))
     }
 }
 
 impl IntoLua for &[u8] {
-    fn into_lua(self, lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, lua: &mut L) -> LuaResult<Val> {
         let r = lua.state_mut().gc.intern_string(self);
         Ok(Val::Str(r))
     }
 }
 
 impl FromLua for String {
-    fn from_lua(val: Val, lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, lua: &L) -> LuaResult<Self> {
         match val {
             Val::Str(r) => {
                 let s = lua
@@ -232,7 +232,7 @@ impl FromLua for String {
 }
 
 impl FromLua for Vec<u8> {
-    fn from_lua(val: Val, lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, lua: &L) -> LuaResult<Self> {
         match val {
             Val::Str(r) => {
                 let s = lua
@@ -253,7 +253,7 @@ impl FromLua for Vec<u8> {
 // ---------------------------------------------------------------------------
 
 impl<T: IntoLua> IntoLua for Option<T> {
-    fn into_lua(self, lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, lua: &mut L) -> LuaResult<Val> {
         match self {
             Some(v) => v.into_lua(lua),
             None => Ok(Val::Nil),
@@ -262,7 +262,7 @@ impl<T: IntoLua> IntoLua for Option<T> {
 }
 
 impl<T: FromLua> FromLua for Option<T> {
-    fn from_lua(val: Val, lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, lua: &L) -> LuaResult<Self> {
         match val {
             Val::Nil => Ok(None),
             other => Ok(Some(T::from_lua(other, lua)?)),
@@ -275,13 +275,13 @@ impl<T: FromLua> FromLua for Option<T> {
 // ---------------------------------------------------------------------------
 
 impl IntoLua for Table {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(Val::Table(self.gc_ref()))
     }
 }
 
 impl FromLua for Table {
-    fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
         match val {
             Val::Table(r) => Ok(Self(r)),
             _ => Err(conversion_error("table", val.type_name())),
@@ -290,13 +290,13 @@ impl FromLua for Table {
 }
 
 impl IntoLua for Function {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(Val::Function(self.gc_ref()))
     }
 }
 
 impl FromLua for Function {
-    fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
         match val {
             Val::Function(r) => Ok(Self(r)),
             _ => Err(conversion_error("function", val.type_name())),
@@ -305,13 +305,13 @@ impl FromLua for Function {
 }
 
 impl IntoLua for Thread {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(Val::Thread(self.gc_ref()))
     }
 }
 
 impl FromLua for Thread {
-    fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
         match val {
             Val::Thread(r) => Ok(Self(r)),
             _ => Err(conversion_error("thread", val.type_name())),
@@ -320,13 +320,13 @@ impl FromLua for Thread {
 }
 
 impl IntoLua for AnyUserData {
-    fn into_lua(self, _lua: &mut Lua) -> LuaResult<Val> {
+    fn into_lua<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Val> {
         Ok(Val::Userdata(self.gc_ref()))
     }
 }
 
 impl FromLua for AnyUserData {
-    fn from_lua(val: Val, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua<L: LuaApi>(val: Val, _lua: &L) -> LuaResult<Self> {
         match val {
             Val::Userdata(r) => Ok(Self(r)),
             _ => Err(conversion_error("userdata", val.type_name())),
@@ -339,13 +339,13 @@ impl FromLua for AnyUserData {
 // ---------------------------------------------------------------------------
 
 impl IntoLuaMulti for Vec<Val> {
-    fn into_lua_multi(self, _lua: &mut Lua) -> LuaResult<Vec<Val>> {
+    fn into_lua_multi<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Vec<Val>> {
         Ok(self)
     }
 }
 
 impl FromLuaMulti for Vec<Val> {
-    fn from_lua_multi(values: &[Val], _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua_multi<L: LuaApi>(values: &[Val], _lua: &L) -> LuaResult<Self> {
         Ok(values.to_vec())
     }
 }
@@ -355,13 +355,13 @@ impl FromLuaMulti for Vec<Val> {
 // ---------------------------------------------------------------------------
 
 impl IntoLuaMulti for () {
-    fn into_lua_multi(self, _lua: &mut Lua) -> LuaResult<Vec<Val>> {
+    fn into_lua_multi<L: LuaApiMut>(self, _lua: &mut L) -> LuaResult<Vec<Val>> {
         Ok(vec![])
     }
 }
 
 impl FromLuaMulti for () {
-    fn from_lua_multi(_values: &[Val], _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua_multi<L: LuaApi>(_values: &[Val], _lua: &L) -> LuaResult<Self> {
         Ok(())
     }
 }
@@ -373,7 +373,7 @@ impl FromLuaMulti for () {
 macro_rules! impl_tuple_multi {
     ($($idx:tt : $T:ident),+) => {
         impl<$($T: IntoLua),+> IntoLuaMulti for ($($T,)+) {
-            fn into_lua_multi(self, lua: &mut Lua) -> LuaResult<Vec<Val>> {
+            fn into_lua_multi<L: LuaApiMut>(self, lua: &mut L) -> LuaResult<Vec<Val>> {
                 Ok(vec![
                     $(self.$idx.into_lua(lua)?,)+
                 ])
@@ -381,7 +381,7 @@ macro_rules! impl_tuple_multi {
         }
 
         impl<$($T: FromLua),+> FromLuaMulti for ($($T,)+) {
-            fn from_lua_multi(values: &[Val], lua: &Lua) -> LuaResult<Self> {
+            fn from_lua_multi<L: LuaApi>(values: &[Val], lua: &L) -> LuaResult<Self> {
                 Ok((
                     $(
                         $T::from_lua(
@@ -423,6 +423,7 @@ fn conversion_error(expected: &str, got: &str) -> LuaError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Lua;
 
     fn make_lua() -> Lua {
         Lua::new_empty()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! # Usage
 //!
 //! ```rust
-//! use rilua::Lua;
+//! use rilua::{Lua, LuaApiMut};
 //!
 //! let mut lua = Lua::new().unwrap();
 //! lua.exec("print(1 + 2)").unwrap();
@@ -23,6 +23,7 @@
 //! assert_eq!(x, 42.0);
 //! ```
 
+pub mod api;
 pub mod compiler;
 pub mod conversion;
 #[cfg(feature = "dynmod")]
@@ -33,10 +34,10 @@ pub(crate) mod platform;
 pub mod stdlib;
 pub mod vm;
 
-use std::any::Any;
 use std::rc::Rc;
 
 // Re-exports for public API.
+pub use api::{LuaApi, LuaApiMut};
 pub use conversion::{FromLua, FromLuaMulti, IntoLua, IntoLuaMulti};
 pub use error::{LuaError, LuaResult, RuntimeError, runtime_error};
 pub use handles::{AnyUserData, Function, Table, Thread};
@@ -105,6 +106,18 @@ pub(crate) fn check_interrupted() -> bool {
 /// struct.
 pub struct Lua {
     state: LuaState,
+}
+
+impl LuaApi for Lua {
+    fn state(&self) -> &LuaState {
+        &self.state
+    }
+}
+
+impl LuaApiMut for Lua {
+    fn state_mut(&mut self) -> &mut LuaState {
+        &mut self.state
+    }
 }
 
 impl Lua {
@@ -177,163 +190,9 @@ impl Lua {
         self.exec_bytes(&source, &name)
     }
 
-    /// Compiles a Lua source string and returns a function handle.
-    ///
-    /// The returned `Function` can be stored and called later. The
-    /// chunk name is set to `"=(string)"`.
-    pub fn load(&mut self, source: &str) -> LuaResult<Function> {
-        self.load_bytes(source.as_bytes(), "=(string)")
-    }
 
-    /// Compiles Lua source bytes (or loads a binary chunk) and returns a function handle.
-    pub fn load_bytes(&mut self, source: &[u8], name: &str) -> LuaResult<Function> {
-        let proto = compile_or_undump(source, name)?;
-        let mut proto = Rc::try_unwrap(proto).unwrap_or_else(|rc| (*rc).clone());
-        patch_string_constants(&mut proto, &mut self.state.gc);
-        let proto = Rc::new(proto);
 
-        let num_upvalues = proto.num_upvalues as usize;
-        let mut lua_cl = LuaClosure::new(proto, self.state.global);
-        for _ in 0..num_upvalues {
-            let uv = vm::closure::Upvalue::new_closed(Val::Nil);
-            let uv_ref = self.state.gc.alloc_upvalue(uv);
-            lua_cl.upvalues.push(uv_ref);
-        }
-        let closure_ref = self.state.gc.alloc_closure(Closure::Lua(lua_cl));
-        Ok(Function(closure_ref))
-    }
 
-    // -----------------------------------------------------------------------
-    // Globals
-    // -----------------------------------------------------------------------
-
-    /// Gets a global variable, converting it to the requested Rust type.
-    ///
-    /// Takes `&mut self` because looking up a string key may need to
-    /// intern the name (idempotent if it already exists).
-    pub fn global<V: FromLua>(&mut self, name: &str) -> LuaResult<V> {
-        let val = self.get_global_val(name);
-        V::from_lua(val, self)
-    }
-
-    /// Sets a global variable from a Rust value.
-    pub fn set_global<V: IntoLua>(&mut self, name: &str, value: V) -> LuaResult<()> {
-        let val = value.into_lua(self)?;
-        self.set_global_val(name, val)
-    }
-
-    // -----------------------------------------------------------------------
-    // Table creation
-    // -----------------------------------------------------------------------
-
-    /// Allocates a new empty table and returns a handle.
-    pub fn create_table(&mut self) -> Table {
-        let r = self.state.gc.alloc_table(vm::table::Table::new());
-        Table(r)
-    }
-
-    // -----------------------------------------------------------------------
-    // Userdata creation
-    // -----------------------------------------------------------------------
-
-    /// Creates a new userdata containing `data` with no metatable.
-    ///
-    /// The returned `AnyUserData` handle can be passed to Lua code or
-    /// stored as a global. Use [`AnyUserData::set_metatable`] to attach
-    /// methods.
-    pub fn create_userdata<T: Any>(&mut self, data: T) -> AnyUserData {
-        let ud = vm::value::Userdata::new(Box::new(data));
-        let r = self.state.gc.alloc_userdata(ud);
-        AnyUserData(r)
-    }
-
-    /// Creates a new userdata with a named, registry-cached metatable.
-    ///
-    /// The metatable is stored in the registry under `type_name`. If a
-    /// metatable for that name already exists, it is reused. This is the
-    /// same pattern used by PUC-Rio's `luaL_newmetatable` for C userdata
-    /// types.
-    pub fn create_typed_userdata<T: Any>(
-        &mut self,
-        data: T,
-        type_name: &str,
-    ) -> LuaResult<AnyUserData> {
-        let mt = stdlib::new_metatable(&mut self.state, type_name)?;
-        let ud = vm::value::Userdata::with_metatable(Box::new(data), mt);
-        let r = self.state.gc.alloc_userdata(ud);
-        Ok(AnyUserData(r))
-    }
-
-    /// Creates or retrieves a named metatable for a userdata type.
-    ///
-    /// The metatable is cached in the registry by `type_name`. Methods
-    /// can be registered on the returned `Table` handle.
-    pub fn create_userdata_metatable(&mut self, type_name: &str) -> LuaResult<Table> {
-        let mt = stdlib::new_metatable(&mut self.state, type_name)?;
-        Ok(Table(mt))
-    }
-
-    // -----------------------------------------------------------------------
-    // Function registration
-    // -----------------------------------------------------------------------
-
-    /// Registers a Rust function as a global Lua function.
-    pub fn register_function(&mut self, name: &str, func: RustFn) -> LuaResult<()> {
-        let closure = Closure::Rust(RustClosure::new(func, name));
-        let closure_ref = self.state.gc.alloc_closure(closure);
-        self.set_global_val(name, Val::Function(closure_ref))
-    }
-
-    // -----------------------------------------------------------------------
-    // GC control
-    // -----------------------------------------------------------------------
-
-    /// Runs a full garbage collection cycle.
-    pub fn gc_collect(&mut self) -> LuaResult<()> {
-        self.state.full_gc()
-    }
-
-    /// Returns the total memory in use by Lua (in bytes).
-    pub fn gc_count(&self) -> usize {
-        self.state.gc.gc_state.total_bytes
-    }
-
-    /// Stops the garbage collector.
-    ///
-    /// Sets the threshold to `usize::MAX` so automatic GC never triggers.
-    /// A subsequent `gc_collect()` resets the threshold, re-enabling auto-GC
-    /// (matching PUC-Rio's behavior).
-    pub fn gc_stop(&mut self) {
-        self.state.gc.gc_state.gc_threshold = usize::MAX;
-    }
-
-    /// Restarts the garbage collector.
-    ///
-    /// Sets the threshold to `total_bytes` so the next allocation
-    /// triggers a GC step (matching PUC-Rio's behavior).
-    pub fn gc_restart(&mut self) {
-        self.state.gc.gc_state.gc_threshold = self.state.gc.gc_state.total_bytes;
-    }
-
-    /// Performs an incremental GC step. Returns true if the step
-    /// finished a collection cycle.
-    pub fn gc_step(&mut self, step_size: i64) -> LuaResult<bool> {
-        self.state.gc_step(step_size)
-    }
-
-    /// Sets the GC pause parameter (percentage). Returns the previous value.
-    pub fn gc_set_pause(&mut self, pause: u32) -> u32 {
-        let old = self.state.gc.gc_state.gc_pause;
-        self.state.gc.gc_state.gc_pause = pause;
-        old
-    }
-
-    /// Sets the GC step multiplier. Returns the previous value.
-    pub fn gc_set_step_multiplier(&mut self, stepmul: u32) -> u32 {
-        let old = self.state.gc.gc_state.gc_stepmul;
-        self.state.gc.gc_state.gc_stepmul = stepmul;
-        old
-    }
 
     // -----------------------------------------------------------------------
     // Calling loaded functions
@@ -536,11 +395,13 @@ impl Lua {
     // -----------------------------------------------------------------------
 
     /// Immutable access to the underlying `LuaState`.
+    #[allow(dead_code)]
     pub(crate) fn state(&self) -> &LuaState {
         &self.state
     }
 
     /// Mutable access to the underlying `LuaState`.
+    #[allow(dead_code)]
     pub(crate) fn state_mut(&mut self) -> &mut LuaState {
         &mut self.state
     }
@@ -581,6 +442,7 @@ impl Lua {
     ///
     /// Uses `intern_string` (idempotent) to get the key reference, then
     /// does a direct table lookup.
+    #[allow(dead_code)]
     fn get_global_val(&mut self, name: &str) -> Val {
         let key_ref = self.state.gc.intern_string(name.as_bytes());
         let Some(global_table) = self.state.gc.tables.get(self.state.global) else {
@@ -590,6 +452,7 @@ impl Lua {
     }
 
     /// Sets a value in the global table by name.
+    #[allow(dead_code)]
     fn set_global_val(&mut self, name: &str, val: Val) -> LuaResult<()> {
         let key_ref = self.state.gc.intern_string(name.as_bytes());
         let key = Val::Str(key_ref);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,22 +391,6 @@ impl Lua {
     }
 
     // -----------------------------------------------------------------------
-    // Internal accessors (pub(crate) for stdlib, conversion, handles)
-    // -----------------------------------------------------------------------
-
-    /// Immutable access to the underlying `LuaState`.
-    #[allow(dead_code)]
-    pub(crate) fn state(&self) -> &LuaState {
-        &self.state
-    }
-
-    /// Mutable access to the underlying `LuaState`.
-    #[allow(dead_code)]
-    pub(crate) fn state_mut(&mut self) -> &mut LuaState {
-        &mut self.state
-    }
-
-    // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
 

--- a/src/vm/state.rs
+++ b/src/vm/state.rs
@@ -27,6 +27,7 @@ use super::metatable::{NUM_TYPE_TAGS, TM_N, TM_NAMES};
 use super::string::{LuaString, StringTable};
 use super::table::Table;
 use super::value::{Userdata, Val};
+use crate::api::{LuaApi, LuaApiMut};
 use crate::error::LuaResult;
 
 // ---------------------------------------------------------------------------
@@ -506,6 +507,37 @@ pub struct LuaState {
     /// Each entry corresponds to one level of nested `resume()` calls.
     /// The deepest resumer is at index 0 (the main thread when no nesting).
     pub saved_threads: Vec<LuaThread>,
+}
+
+
+impl LuaApi for LuaState {
+    fn state(&self) -> &LuaState {
+        self
+    }
+}
+
+impl LuaApiMut for LuaState {
+    fn state_mut(&mut self) -> &mut LuaState {
+        self
+    }
+}
+
+impl LuaApi for &LuaState {
+    fn state(&self) -> &LuaState {
+        self
+    }
+}
+
+impl LuaApi for &mut LuaState {
+    fn state(&self) -> &LuaState {
+        self
+    }
+}
+
+impl LuaApiMut for &mut LuaState {
+    fn state_mut(&mut self) -> &mut LuaState {
+        self
+    }
 }
 
 impl LuaState {
@@ -1312,6 +1344,8 @@ impl Default for LuaState {
 
 #[cfg(test)]
 mod tests {
+    use crate::{Function, Lua};
+
     use super::*;
 
     // ----- LuaState construction -----
@@ -1600,5 +1634,128 @@ mod tests {
         assert_eq!(MASK_RET, 2);
         assert_eq!(MASK_LINE, 4);
         assert_eq!(MASK_COUNT, 8);
+    }
+
+    // -- LuaApi trait tests --
+
+    #[test]
+    fn lua_api_read_with_ref_state() {
+        let mut lua = Lua::new_empty();
+        #[allow(unused_mut)]
+        let mut state_mut = &mut lua.state;
+        let t = state_mut.create_table();
+        state_mut.table_raw_set(&t, Val::Num(1.0), Val::Num(100.0)).ok();
+        
+        // Test immutable operations with &LuaState
+        let state_ref = &lua.state;
+        let count = state_ref.gc_count();
+        assert!(count > 0);
+        
+        let v = state_ref.table_raw_get(&t, Val::Num(1.0));
+        assert_eq!(v.ok(), Some(Val::Num(100.0)));
+        
+        let len = state_ref.table_raw_len(&t);
+        assert_eq!(len, 1);
+    }
+
+    #[test]
+    fn lua_api_with_mut_state_global() {
+        let mut lua = Lua::new_empty();
+        let state = &mut lua.state;
+        
+        state.set_global("test_var", 42.0f64).ok();
+        let val: LuaResult<f64> = state.global("test_var");
+        assert_eq!(val.ok(), Some(42.0));
+    }
+
+    #[test]
+    fn lua_api_with_mut_state_create_table() {
+        let mut lua = Lua::new_empty();
+        let state = &mut lua.state;
+        
+        let t = state.create_table();
+        state.table_raw_set(&t, Val::Num(1.0), Val::Num(100.0)).ok();
+        let v = state.table_raw_get(&t, Val::Num(1.0));
+        assert_eq!(v.ok(), Some(Val::Num(100.0)));
+    }
+
+    #[test]
+    fn lua_api_with_mut_state_create_string() {
+        let mut lua = Lua::new_empty();
+        let state = &mut lua.state;
+        
+        let val = state.create_string(b"test");
+        assert!(matches!(val, Val::Str(_)));
+    }
+
+    #[test]
+    fn lua_api_with_mut_state_gc_operations() {
+        let mut lua = Lua::new_empty();
+        let state = &mut lua.state;
+        
+        let count = state.gc_count();
+        assert!(count > 0);
+        
+        state.gc_stop();
+        assert_eq!(state.gc.gc_state.gc_threshold, usize::MAX);
+        
+        state.gc_restart();
+        assert_eq!(state.gc.gc_state.gc_threshold, state.gc.gc_state.total_bytes);
+    }
+
+    #[test]
+    fn lua_api_with_mut_state_register_function() {
+        let mut lua = Lua::new_empty();
+        let state = &mut lua.state;
+        
+        let result = state.register_function("test_fn", |s| {
+            s.push(Val::Num(123.0));
+            Ok(1)
+        });
+        assert!(result.is_ok());
+        
+        let val: LuaResult<Val> = state.global("test_fn");
+        assert!(matches!(val.ok(), Some(Val::Function(_))));
+    }
+
+    #[test]
+    fn lua_api_with_mut_state_create_userdata() {
+        let mut lua = Lua::new_empty();
+        let state = &mut lua.state;
+        
+        let ud = state.create_userdata(999i64);
+        let borrowed = ud.borrow::<i64>(&state);
+        assert_eq!(borrowed, Some(&999i64));
+    }
+
+    #[test]
+    fn lua_api_with_mut_state_load_and_compile() {
+        let mut lua = Lua::new_empty();
+        let state = &mut lua.state;
+        
+        let func = state.load("return 1 + 2");
+        assert!(func.is_ok());
+        assert!(matches!(func.ok(), Some(Function(_))));
+    }
+
+    #[test]
+    fn lua_api_generic_mutable() {
+        fn set_value<L: LuaApiMut>(lua: &mut L, name: &str, value: f64) -> LuaResult<()> {
+            lua.set_global(name, value)
+        }
+        
+        fn get_value<L: LuaApiMut>(lua: &mut L, name: &str) -> LuaResult<f64> {
+            lua.global(name)
+        }
+        
+        let mut lua = Lua::new_empty();
+        set_value(&mut lua, "x", 99.0).ok();
+        let val = get_value(&mut lua, "x");
+        assert_eq!(val.ok(), Some(99.0));
+        
+        let state = &mut lua.state;
+        set_value(state, "y", 88.0).ok();
+        let val = get_value(state, "y");
+        assert_eq!(val.ok(), Some(88.0));
     }
 }


### PR DESCRIPTION
# Pull Request

**As it was mostly renaming and moving code I heavily used BOB for this**

## Summary
I want to access the `Lua` struct api within a registered function. By extracting the API into two traits its now possible.

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Check the type of change this PR introduces -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvements
- [ ] Build system/dependency changes

### Tested On

<!-- Check all that apply -->

- [x] Linux
- [ ] macOS
- [ ] Windows

### WoW Versions Tested

<!-- If applicable, check versions you've tested with -->

- [ ] Classic Era (1.13.x/1.14.x/1.15.x)
- [ ] TBC Classic (2.5.x)
- [ ] Wrath Classic (3.4.x)
- [ ] Cata Classic (4.4.x)
- [ ] MoP Remix (5.5.x)
- [ ] Vanilla (1.x)
- [ ] TBC (2.x)
- [ ] WotLK (3.x)
- [ ] Cataclysm (4.x)
- [ ] MoP (5.x)
- [ ] N/A (not related to WoW file formats)

## Quality Checklist

<!-- Confirm you've completed these steps -->

- [ ] Code follows project style guidelines
- [ ] Self-review of code completed
- [x] Tests pass locally
- [ ] Documentation updated (if applicable)

---

**By submitting this PR, I confirm that:**

- [x] I have read and agree to the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I am willing to address feedback and make necessary changes
