### PR TITLE
chore: release v0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.22](https://github.com/wowemulation-dev/rilua/compare/v0.1.21...v0.1.22) - 2026-08-24
+
+### Added
+
+- *(api)* expose check_/push_/error helpers on LuaState
+
+### Documentation
+
+- update unsafe code descriptions across project docs
+
+### Fixed
+
+- *(ci)* silence unknown lint on MSRV toolchain
+
+### Changelog
+
+- add unreleased entries for compiler, docs, tooling, and fixes
+
+### Compiler
+
+- fix debug line numbers and PUC-Rio ordering
+
+### Examples
+
+- fix import ordering and formatting
+
+### Tooling
+
+- switch from markdownlint-cli2 to markdownlint-cli
+
+### Vm
+
+- fix line continuation in arg_error
+
 ### Compiler
 
 - fix debug line numbers to use self.current_line for accurate source positions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "criterion",
  "flamegraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.21"
+version = "0.1.22"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.21 -> 0.1.22

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.22](https://github.com/wowemulation-dev/rilua/compare/v0.1.21...v0.1.22) - 2026-08-24

### Added

- *(api)* expose check_/push_/error helpers on LuaState

### Documentation

- update unsafe code descriptions across project docs

### Fixed

- *(ci)* silence unknown lint on MSRV toolchain

### Changelog

- add unreleased entries for compiler, docs, tooling, and fixes

### Compiler

- fix debug line numbers and PUC-Rio ordering

### Examples

- fix import ordering and formatting

### Tooling

- switch from markdownlint-cli2 to markdownlint-cli

### Vm

- fix line continuation in arg_error

### Compiler

- fix debug line numbers to use self.current_line for accurate source positions
- reorder remove_locals before emit_abc(Return) to match PUC-Rio close_func ordering
- remove unused (for step) local variable from numeric for loop
- use self.current_span() in lexer for accurate span info in string tokens

### Documentation

- clarify unsafe code boundaries (confined to libc FFI and dynmod)
- update comparison table with actual unsafe code descriptions
- remove misleading binary compatibility non-goal

### Tooling

- switch from markdownlint-cli2 to markdownlint-cli

### Fixes

- fix import ordering in examples
- fix line continuation in vm/state.rs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).