### PR TITLE
chore: release v0.1.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.24](https://github.com/wowemulation-dev/rilua/compare/v0.1.23...v0.1.24) - 2026-08-24
+
+### Testing
+
+- add regression test for issue #46 nil field call misattribution
+
 ## [0.1.22](https://github.com/wowemulation-dev/rilua/compare/v0.1.21...v0.1.22) - 2026-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "rilua"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "criterion",
  "flamegraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rilua"
-version = "0.1.23"
+version = "0.1.24"
 authors = ["Daniel S. Reichenbach <daniel@kogito.network>"]
 description = "Lua 5.1.1 implemented in Rust, targeting the World of Warcraft addon variant."
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `rilua`: 0.1.23 -> 0.1.24

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.24](https://github.com/wowemulation-dev/rilua/compare/v0.1.23...v0.1.24) - 2026-08-24

### Testing

- add regression test for issue #46 nil field call misattribution
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).